### PR TITLE
update dropbox content host because more servers are behind new host

### DIFF
--- a/lib/rest-core/client/dropbox.rb
+++ b/lib/rest-core/client/dropbox.rb
@@ -77,12 +77,12 @@ module RestCore::Dropbox::Client
   end
 
   def download path, query={}, opts={}
-    get("https://api-content.dropbox.com/1/files/#{root}/#{path}",
+    get("https://content.dropboxapi.com/1/files/#{root}/#{path}",
         query, {:json_response => false}.merge(opts))
   end
 
   def upload path, file, query={}, opts={}
-    put("https://api-content.dropbox.com/1/files_put/#{root}/#{path}",
+    put("https://content.dropboxapi.com/1/files_put/#{root}/#{path}",
         file, query, opts)
   end
 


### PR DESCRIPTION
$ dig api-content.dropbox.com +short
dl-balancer.x.dropbox.com.
50.17.186.19

$ dig content.dropboxapi.com +short
duc-balancer.x.dropbox.com.
23.23.107.71
184.73.202.105
23.23.104.102
50.16.197.250
50.19.252.141
184.73.234.181
23.21.141.200
50.19.85.216
